### PR TITLE
Add mimic tags to carriage joint

### DIFF
--- a/urdf/generated/wxai/wxai_base.urdf
+++ b/urdf/generated/wxai/wxai_base.urdf
@@ -209,6 +209,7 @@
     <origin rpy="0 0 0" xyz="0.0865 -0.023 0"/>
     <parent link="link_6"/>
     <child link="carriage_right"/>
+    <mimic joint="left_carriage_joint"/>
     <axis xyz="0 -1 0"/>
     <limit effort="400.0" lower="0.0" upper="0.044" velocity="0.0875"/>
   </joint>
@@ -297,10 +298,5 @@
     <child link="ee_gripper_link"/>
     <axis xyz="1 0 0"/>
   </joint>
-  <link name="ee_gripper_link">
-    <inertial>
-      <mass value="0.001"/>
-      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
-    </inertial>
-  </link>
+  <link name="ee_gripper_link"/>
 </robot>

--- a/urdf/generated/wxai/wxai_follower.urdf
+++ b/urdf/generated/wxai/wxai_follower.urdf
@@ -209,6 +209,7 @@
     <origin rpy="0 0 0" xyz="0.0865 -0.023 0"/>
     <parent link="link_6"/>
     <child link="carriage_right"/>
+    <mimic joint="left_carriage_joint"/>
     <axis xyz="0 -1 0"/>
     <limit effort="400.0" lower="0.0" upper="0.044" velocity="0.0875"/>
   </joint>
@@ -404,10 +405,5 @@
     <child link="ee_gripper_link"/>
     <axis xyz="1 0 0"/>
   </joint>
-  <link name="ee_gripper_link">
-    <inertial>
-      <mass value="0.001"/>
-      <inertia ixx="0.0001" ixy="0" ixz="0" iyy="0.0001" iyz="0" izz="0.0001"/>
-    </inertial>
-  </link>
+  <link name="ee_gripper_link"/>
 </robot>

--- a/urdf/generated/wxai/wxai_leader_left.urdf
+++ b/urdf/generated/wxai/wxai_leader_left.urdf
@@ -209,6 +209,7 @@
     <origin rpy="0 0 0" xyz="0.0865 -0.023 0"/>
     <parent link="link_6"/>
     <child link="carriage_right"/>
+    <mimic joint="left_carriage_joint"/>
     <axis xyz="0 -1 0"/>
     <limit effort="400.0" lower="0.0" upper="0.044" velocity="0.0875"/>
   </joint>

--- a/urdf/generated/wxai/wxai_leader_right.urdf
+++ b/urdf/generated/wxai/wxai_leader_right.urdf
@@ -209,6 +209,7 @@
     <origin rpy="0 0 0" xyz="0.0865 -0.023 0"/>
     <parent link="link_6"/>
     <child link="carriage_right"/>
+    <mimic joint="left_carriage_joint"/>
     <axis xyz="0 -1 0"/>
     <limit effort="400.0" lower="0.0" upper="0.044" velocity="0.0875"/>
   </joint>

--- a/urdf/macros/_wxai.urdf.xacro
+++ b/urdf/macros/_wxai.urdf.xacro
@@ -366,6 +366,7 @@
         rpy="0 0 0" />
       <parent link="${prefix}link_6" />
       <child link="${prefix}carriage_right" />
+      <mimic joint="${prefix}left_carriage_joint" />
       <axis xyz="0 -1 0" />
       <limit
         lower="0.0"


### PR DESCRIPTION
Reference: https://github.com/haosulab/ManiSkill/pull/904#issuecomment-2946084103

This PR does the following:
* Removes unnecessary inertial properties from the ee_gripper_link
* Makes the right carriage joint mimic the left carriage joint
