### PR TITLE
Jazzy support

### DIFF
--- a/urdf/macros/_wxai.ros2_control.xacro
+++ b/urdf/macros/_wxai.ros2_control.xacro
@@ -22,7 +22,7 @@
 
       <hardware>
         <xacro:if value="${ros2_control_hardware_type == 'mock_components'}">
-          <plugin>fake_components/GenericSystem</plugin>
+          <plugin>mock_components/GenericSystem</plugin>
         </xacro:if>  <!-- ros2_control_hardware_type == 'mock_components' -->
 
         <xacro:if value="${ros2_control_hardware_type == 'real'}">


### PR DESCRIPTION
This PR updates the namespace of the mocked hardware interface according to jazzy.

Related PR: https://github.com/TrossenRobotics/trossen_arm_ros/pull/18