### PR TITLE
Pass arm variant to ros2_control hardware interface macro

### DIFF
--- a/launch/display.launch.py
+++ b/launch/display.launch.py
@@ -39,8 +39,9 @@ from launch.substitutions import (
     PathJoinSubstitution,
 )
 from launch_ros.actions import Node
-from launch_ros.substitutions import FindPackageShare
 from launch_ros.parameter_descriptions import ParameterValue
+from launch_ros.substitutions import FindPackageShare
+
 
 def launch_setup(context, *args, **kwargs):
     use_rviz_launch_arg = LaunchConfiguration('use_rviz')
@@ -158,14 +159,14 @@ def generate_launch_description():
         DeclareLaunchArgument(
             'robot_description',
             default_value=Command([
-            FindExecutable(name='xacro'), ' ',
-            PathJoinSubstitution([
-                FindPackageShare('trossen_arm_description'),
-                'urdf',
-                LaunchConfiguration('robot_model'),
-                ]), '.urdf.xacro ',
-            'variant:=', LaunchConfiguration('arm_variant'), ' ',
-            'arm_side:=', LaunchConfiguration('arm_side'), ' ',
+                FindExecutable(name='xacro'), ' ',
+                PathJoinSubstitution([
+                    FindPackageShare('trossen_arm_description'),
+                    'urdf',
+                    LaunchConfiguration('robot_model'),
+                    ]), '.urdf.xacro ',
+                'variant:=', LaunchConfiguration('arm_variant'), ' ',
+                'arm_side:=', LaunchConfiguration('arm_side'), ' ',
             ])
         )
     )

--- a/urdf/macros/_wxai.ros2_control.xacro
+++ b/urdf/macros/_wxai.ros2_control.xacro
@@ -16,7 +16,7 @@
     </joint>
   </xacro:macro>
 
-  <xacro:macro name="wxai_ros2_control" params="prefix ros2_control_hardware_type ip_address">
+  <xacro:macro name="wxai_ros2_control" params="prefix ros2_control_hardware_type ip_address variant">
 
     <ros2_control name="TrossenArmHardwareInterface" type="system">
 
@@ -27,7 +27,8 @@
 
         <xacro:if value="${ros2_control_hardware_type == 'real'}">
           <plugin>trossen_arm_hardware/TrossenArmHardwareInterface</plugin>
-          <param name="robot_model">0</param>        <!-- 0: wxai_v0 -->
+          <param name="robot_model">0</param>             <!-- 0: wxai_v0 -->
+          <param name="end_effector">${variant}</param>   <!-- 'base', 'follower' -->
           <param name="ip_address">${ip_address}</param>
         </xacro:if>  <!-- ros2_control_hardware_type == 'real' -->
       </hardware>

--- a/urdf/macros/_wxai.urdf.xacro
+++ b/urdf/macros/_wxai.urdf.xacro
@@ -17,7 +17,8 @@
     <xacro:wxai_ros2_control
       prefix="${prefix}"
       ip_address="${ip_address}"
-      ros2_control_hardware_type="${ros2_control_hardware_type}"/>
+      ros2_control_hardware_type="${ros2_control_hardware_type}"
+      end_effector="${variant}"/>
 
     <link name="${prefix}base_link">
       <inertial>

--- a/urdf/macros/_wxai.urdf.xacro
+++ b/urdf/macros/_wxai.urdf.xacro
@@ -18,7 +18,7 @@
       prefix="${prefix}"
       ip_address="${ip_address}"
       ros2_control_hardware_type="${ros2_control_hardware_type}"
-      end_effector="${variant}"/>
+      variant="${variant}"/>
 
     <link name="${prefix}base_link">
       <inertial>


### PR DESCRIPTION
This PR allows users to specify the end effector/arm variant when instantiating their wxai macro.