### PR TITLE
Add support for configurable command interface (position/effort)

### DIFF
--- a/urdf/macros/_wxai.ros2_control.xacro
+++ b/urdf/macros/_wxai.ros2_control.xacro
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="ros2_control_joint" params="name">
+  <xacro:macro name="ros2_control_joint" params="name command_interface:='position'">
     <joint name="${name}">
-      <command_interface name="position"/>
+      <command_interface name="${command_interface}"/>
       <state_interface name="position">
         <param name="initial_value">0.0</param>
       </state_interface>
@@ -16,7 +16,7 @@
     </joint>
   </xacro:macro>
 
-  <xacro:macro name="wxai_ros2_control" params="prefix ros2_control_hardware_type ip_address variant">
+  <xacro:macro name="wxai_ros2_control" params="prefix ros2_control_hardware_type ip_address variant command_interface:='position'">
 
     <ros2_control name="TrossenArmHardwareInterface" type="system">
 
@@ -33,15 +33,15 @@
         </xacro:if>  <!-- ros2_control_hardware_type == 'real' -->
       </hardware>
 
-      <xacro:ros2_control_joint name="${prefix}joint_0"/>
-      <xacro:ros2_control_joint name="${prefix}joint_1"/>
-      <xacro:ros2_control_joint name="${prefix}joint_2"/>
-      <xacro:ros2_control_joint name="${prefix}joint_3"/>
-      <xacro:ros2_control_joint name="${prefix}joint_4"/>
-      <xacro:ros2_control_joint name="${prefix}joint_5"/>
+      <xacro:ros2_control_joint name="${prefix}joint_0" command_interface="${command_interface}"/>
+      <xacro:ros2_control_joint name="${prefix}joint_1" command_interface="${command_interface}"/>
+      <xacro:ros2_control_joint name="${prefix}joint_2" command_interface="${command_interface}"/>
+      <xacro:ros2_control_joint name="${prefix}joint_3" command_interface="${command_interface}"/>
+      <xacro:ros2_control_joint name="${prefix}joint_4" command_interface="${command_interface}"/>
+      <xacro:ros2_control_joint name="${prefix}joint_5" command_interface="${command_interface}"/>
 
       <joint name="${prefix}left_carriage_joint">
-        <command_interface name="position" />
+        <command_interface name="${command_interface}"/>
         <state_interface name="position">
           <param name="initial_value">0.0</param>
         </state_interface>

--- a/urdf/macros/_wxai.urdf.xacro
+++ b/urdf/macros/_wxai.urdf.xacro
@@ -8,7 +8,7 @@
     value="6"
     scope="local"/>
 
-  <xacro:macro name="wxai" params="variant arm_side:='' prefix:='' ros2_control_hardware_type ip_address">
+  <xacro:macro name="wxai" params="variant arm_side:='' prefix:='' ros2_control_hardware_type ip_address command_interface:='position'">
 
     <xacro:property name="mesh_directory" value="package://trossen_arm_description/meshes/${robot_model}"/>
 
@@ -18,7 +18,8 @@
       prefix="${prefix}"
       ip_address="${ip_address}"
       ros2_control_hardware_type="${ros2_control_hardware_type}"
-      variant="${variant}"/>
+      variant="${variant}"
+      command_interface="${command_interface}"/>
 
     <link name="${prefix}base_link">
       <inertial>

--- a/urdf/wxai.urdf.xacro
+++ b/urdf/wxai.urdf.xacro
@@ -8,6 +8,7 @@
   <xacro:arg name="ros2_control_hardware_type"      default="real"/>        <!-- 'real', 'mock_components' -->
   <xacro:arg name="ip_address"                      default="192.168.1.2"/>
   <xacro:arg name="base_link_frame"                 default="base_link"/>
+  <xacro:arg name="command_interface"               default="position"/>    <!-- 'position', 'effort' -->
 
   <xacro:if value="$(arg use_world_frame)">
     <link name="world"/>
@@ -29,6 +30,7 @@
     arm_side="$(arg arm_side)"
     prefix="$(arg prefix)"
     ros2_control_hardware_type="$(arg ros2_control_hardware_type)"
-    ip_address="$(arg ip_address)"/>
+    ip_address="$(arg ip_address)"
+    command_interface="$(arg command_interface)"/>
 
 </robot>


### PR DESCRIPTION
This PR adds support for configurable command interfaces to the WXAI URDF description, enabling both position and effort control modes.

The parameter accepts position or effort values and maintains full backward compatibility by defaulting to position control.

Related PR: This change works in conjunction with the hardware interface updates in trossen_arm_ros PR.